### PR TITLE
updated tmux version

### DIFF
--- a/tutorial/Dockerfile.4
+++ b/tutorial/Dockerfile.4
@@ -1,6 +1,6 @@
 FROM tutorial:3
 
-ENV TMUX_VERSION 2.6
+ENV TMUX_VERSION 2.7
 
 ENV TMUX_TAR "tmux-$TMUX_VERSION.tar.gz"
 

--- a/tutorial/readme.md
+++ b/tutorial/readme.md
@@ -281,7 +281,7 @@ The only real way to get tmux is to build it from source. Luckily, there are
 plenty of resources showing how to build it on Ubuntu:
 ```dockerfile
 
-ENV TMUX_VERSION 2.6
+ENV TMUX_VERSION 2.7
 
 ENV TMUX_TAR "tmux-$TMUX_VERSION.tar.gz"
 


### PR DESCRIPTION
Fixes: #58 

`2.6` -> `2.7`

https://github.com/tmux/tmux/wiki is updated to `2.7` as stable now.

