### PR TITLE
Create docker ssh mountpoint and set permissions

### DIFF
--- a/images/ubuntu-dev-base/build.sh
+++ b/images/ubuntu-dev-base/build.sh
@@ -136,6 +136,11 @@ apt-install iproute2
 # used all the time
 apt-install -y zip unzip
 
+# create magic docker ssh mountpoint and set permissions
+mkdir -p /run/host-services
+touch /run/host-services/ssh-auth.sock
+chown aghost-7: /run/host-services/ssh-auth.sock
+
 # Expose local servers to the internet. Useful for testing webhooks, oauth,
 # etc.
 curl -o /tmp/ngrok.zip \


### PR DESCRIPTION
The old ssh forwarding method of mounting the sock no longer works in MacOS. This change just creates the mountpoint and sets the permissions appropriately so that `/run/host-services/ssh-auth.sock` can be accessed by the aghost-7 user. The conversation from the docker team can be found here https://github.com/docker/for-mac/issues/410.